### PR TITLE
fix: resolve remaining CI lint errors after Phase 3 merges

### DIFF
--- a/src/components/LMSPanel.tsx
+++ b/src/components/LMSPanel.tsx
@@ -232,10 +232,6 @@ function LMSPanelContent() {
   );
 }
 
-// ─── LRSConfig type re-export for inline cast ──────────────────────────────────
-
-import type { LRSConfig } from '../lms/xapiClient';
-
 // ─── Main export ──────────────────────────────────────────────────────────────
 
 export default function LMSPanel() {

--- a/src/components/SedationGauge.tsx
+++ b/src/components/SedationGauge.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import useSimStore from '../store/useSimStore';
 import useAIStore from '../store/useAIStore';

--- a/src/components/TrendGraph.tsx
+++ b/src/components/TrendGraph.tsx
@@ -130,17 +130,6 @@ export default function TrendGraph() {
     )
   ), [displayData]);
 
-  if (displayData.length === 0) {
-    return (
-      <div className="flex-1 flex items-center justify-center text-gray-500 bg-sim-panel p-4">
-        <div className="text-center text-xs">
-          <p>Start the simulation</p>
-          <p className="text-gray-600 mt-1">Trends will appear here</p>
-        </div>
-      </div>
-    );
-  }
-
   // Pre-compute per-vital chart data (depends only on displayData, not on vitals)
   const vitalChartData = useMemo(() =>
     Object.fromEntries(
@@ -153,6 +142,17 @@ export default function TrendGraph() {
       ])
     ) as Record<string, { time: string; value: number }[]>,
   [displayData]);
+
+  if (displayData.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-gray-500 bg-sim-panel p-4">
+        <div className="text-center text-xs">
+          <p>Start the simulation</p>
+          <p className="text-gray-600 mt-1">Trends will appear here</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="bg-sim-panel overflow-auto">

--- a/src/engine/ScenarioEngine.ts
+++ b/src/engine/ScenarioEngine.ts
@@ -943,9 +943,9 @@ export class ScenarioEngine {
     }
 
     // JSON scenario checklist scoring summary
-    let percentScore = 0;
-    let rawScore = 0;
-    let maxScore = 100;
+    let percentScore: number;
+    let rawScore: number;
+    let maxScore: number;
     if (this.jsonScenario) {
       const jsonScore = evaluateJsonScore(this.jsonScenario, this.jsonAnswers);
       percentScore = jsonScore.percentScore;


### PR DESCRIPTION
## Summary
- Fix all 4 remaining lint errors that are failing the CI Lint job on main
- Previous commit (9b8e600) fixed test failures but not lint errors

## Changes
- **SedationGauge.tsx**: Remove unused `useMemo` import (`@typescript-eslint/no-unused-vars`)
- **TrendGraph.tsx**: Move `useMemo` call above early return to fix conditional hook (`react-hooks/rules-of-hooks`)
- **ScenarioEngine.ts**: Use uninitialized `let` for always-assigned variables (`no-useless-assignment`)
- **LMSPanel.tsx**: Remove duplicate unused `LRSConfig` type import (`@typescript-eslint/no-unused-vars`)

## Test plan
- [x] `npm run lint` — 0 errors, 13 warnings (all pre-existing `react-hooks/set-state-in-effect`)
- [x] `npm run typecheck` — clean
- [x] `npm test` — all passed
- [x] `npx vitest run` — 150/150 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)