### PR TITLE
fix(deps): unblock npm ci (drop unused RRD v5 types, add legacy-peer-deps)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# The devDependencies pin bleeding-edge tooling (e.g. eslint@10) whose peer
+# ranges the plugin ecosystem hasn't caught up to yet — notably
+# eslint-plugin-react-hooks@7 does not yet declare eslint@10 support. The
+# packages work together in practice, so accept npm's resolution rather than
+# fail the install. Revisit once the plugins publish eslint@10-compatible peers.
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "sedsim",
       "version": "0.1.0",
       "dependencies": {
-        "@types/react-router-dom": "^5.3.3",
         "i18next": "^25.8.17",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4063,12 +4062,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "license": "MIT"
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -4128,12 +4121,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4148,27 +4143,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@types/react-router-dom": "^5.3.3",
     "i18next": "^25.8.17",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Problem
`npm ci` fails on a clean checkout with `ERESOLVE`, forcing contributors and CI to use `--legacy-peer-deps` manually.

## Root causes & fixes
1. **`@types/react-router-dom@^5.3.3`** is declared, but the project uses **`react-router-dom@7`**, which ships its own types. The v5 types are unused and version-mismatched → **removed** from `dependencies`.
2. The devDependencies pin **bleeding-edge tooling** (`eslint@10`, released 2026) whose peer ranges the plugin ecosystem hasn't caught up to — specifically **`eslint-plugin-react-hooks@7.0.1` doesn't declare `eslint@10` support**. They work together in practice, so I added an **`.npmrc` with `legacy-peer-deps=true`** to accept npm's resolution rather than fail the install.

## Verification
```
rm -rf node_modules && npm ci   # now succeeds with no flags
```
Lockfile diff is minimal (just drops the `@types/react-router-dom` subtree).

## Follow-up
Once `eslint-plugin-react-hooks` (and friends) publish `eslint@10`-compatible peer ranges, the `.npmrc` escape hatch can be removed. Independent of the Liquid Glass PR (#158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)