### PR TITLE
fix(landing): wrap nav links on narrow screens

### DIFF
--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -228,6 +228,11 @@ export default function LandingPage() {
         .qd-nav { position:sticky; top:0; z-index:20; }
         .qd-nav.qd-glass { border-radius:0; border-left:none; border-right:none; border-top:none; }
         .qd-nav.qd-glass::before { border-radius:0; }
+        /* Narrow screens: stop the links crowding the brand — wrap and centre. */
+        @media (max-width: 640px) {
+          .qd-nav { flex-wrap:wrap; justify-content:center; gap:8px 18px; padding:14px 20px; text-align:center; }
+          .qd-nav > div { flex-wrap:wrap; justify-content:center; gap:12px 18px; }
+        }
 
         @media (prefers-reduced-transparency: reduce) {
           .qd-glass { -webkit-backdrop-filter:none; backdrop-filter:none; background: rgba(28,20,9,0.92); }


### PR DESCRIPTION
## Problem
The landing-page nav has no mobile handling — on phones the links (`Substack · Gengyve · SedSim · Instructor`) crowd the brand and clip past the right edge.

## Fix
A single `@media (max-width: 640px)` rule lets `.qd-nav` wrap and centres the link group. **CSS-only and additive** — no JSX changes, desktop layout unchanged.

## Verification
Ran the dev server at 375px: `flex-wrap` applies, links no longer overflow the nav, brand and links wrap cleanly onto centred rows.

## Note on base branch
Stacked on **#158** (`feat/liquid-glass-landing`), because that PR is where the nav gained the `.qd-nav` class this rule targets. Merge #158 first; GitHub will retarget this to `main` automatically. If you'd rather have it standalone against `main`, I can rebase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)