### PR TITLE
fix(types): import ProactiveTriggerType from its real source (./mentor)

### DIFF
--- a/src/ai/simMasterBridge.ts
+++ b/src/ai/simMasterBridge.ts
@@ -13,7 +13,8 @@
  */
 
 import type { TeachingMode, SimMasterV4Annotation } from '../store/slices/aiSlice';
-import type { SimMasterContext, ProactiveTriggerType } from './simMaster';
+import type { SimMasterContext } from './simMaster';
+import type { ProactiveTriggerType } from './mentor';
 import {
   evaluateV4Patterns,
   triggerToAnnotations,


### PR DESCRIPTION
## Problem
The CI **Typecheck** job (`npm run typecheck` → `tsc --noEmit`) is **red on `main`**:

```
src/ai/simMasterBridge.ts(16,33): error TS2614: Module '"./simMaster"' has no
exported member 'ProactiveTriggerType'. Did you mean to use 'import
ProactiveTriggerType from "./simMaster"' instead?
```

`simMasterBridge.ts` imported `ProactiveTriggerType` from `./simMaster`, but `simMaster.ts` only **imports** that type from `./mentor` for its own internal use and never **re-exports** it. `mentor.ts` is where it's actually `export`ed (line 199).

## Fix
Import the type directly from `./mentor`. `SimMasterContext` still comes from `./simMaster` (which does export it). **Type-only change — zero runtime impact.**

```diff
-import type { SimMasterContext, ProactiveTriggerType } from './simMaster';
+import type { SimMasterContext } from './simMaster';
+import type { ProactiveTriggerType } from './mentor';
```

## Verification
```
npm run typecheck   # now passes clean
```

## Context
Pre-existing breakage, unrelated to the Liquid Glass work — but since it turns the Typecheck check red on every open PR, this gets the whole CI green again. Independent of #158 / #159 / #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)