### PR TITLE
fix(landing): wrap nav links on narrow screens

### DIFF
--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -228,6 +228,11 @@ export default function LandingPage() {
         .qd-nav { position:sticky; top:0; z-index:20; }
         .qd-nav.qd-glass { border-radius:0; border-left:none; border-right:none; border-top:none; }
         .qd-nav.qd-glass::before { border-radius:0; }
+        /* Narrow screens: stop the links crowding the brand — wrap and centre. */
+        @media (max-width: 640px) {
+          .qd-nav { flex-wrap:wrap; justify-content:center; gap:8px 18px; padding:14px 20px; text-align:center; }
+          .qd-nav > div { flex-wrap:wrap; justify-content:center; gap:12px 18px; }
+        }
 
         @media (prefers-reduced-transparency: reduce) {
           .qd-glass { -webkit-backdrop-filter:none; backdrop-filter:none; background: rgba(28,20,9,0.92); }


### PR DESCRIPTION
Re-targets the nav mobile fix to `main` (the original #160 auto-closed when its base branch `feat/liquid-glass-landing` was deleted on merge of #158).

CSS-only, additive `@media (max-width: 640px)` rule so the landing nav links wrap and centre instead of clipping past the right edge on phones. The glass changes this builds on are already in `main` via #158, so the diff here is just the nav rule. Verified at 375px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)