### PR TITLE
chore(netlify): capture build config in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,19 @@
+# Netlify build configuration, captured in-repo for reproducibility.
+# Mirrors the existing dashboard settings — no behavioural change.
+#
+# Notes:
+# - Netlify sets NETLIFY=true during builds, which flips vite.config.ts to
+#   base:'/' (the apex-domain build). No need to set it here.
+# - SPA routing lives in public/_redirects (copied into dist on build); kept
+#   there rather than duplicated below.
+# - Secrets / per-context vars (e.g. VITE_CLAUDE_PROXY_URL) stay in the Netlify
+#   dashboard, not in source control.
+# - Dependency install is automatic; .npmrc (legacy-peer-deps=true) is honoured.
+
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  # Pin to the Node version CI builds and tests against.
+  NODE_VERSION = "20"


### PR DESCRIPTION
Captures the Netlify production build settings in-repo so they're not dashboard-only.

```toml
[build]
  command = "npm run build"
  publish = "dist"
[build.environment]
  NODE_VERSION = "20"
```

**Zero behavioural change** — verified by running `NETLIFY=true npm run build` locally, which produced asset hashes **byte-identical to the live deploy** (`index-D_2neTJ1.js`, `vendor-react-B0CJLGM5.js`, `index-BQs_r8w5.css`).

- `NETLIFY=true` (set automatically by Netlify) flips `vite.config.ts` to `base:'/'` — confirmed root `/assets/` paths in output.
- SPA routing stays in `public/_redirects`; not duplicated here.
- Secrets / per-context vars (e.g. `VITE_CLAUDE_PROXY_URL`) stay in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)