### PR TITLE
Return a real 404 instead of the home page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not found — The Quantum Distillery</title>
+    <!--
+      A page that does not exist must say so with a 404 status, not a 200.
+      Netlify serves this file via the catch-all rule in public/_redirects.
+
+      Deliberately static: it must render even if the JS bundle is the thing
+      that failed, and a crawler hitting a dead URL should not need to boot
+      React to be told the page is gone.
+    -->
+    <meta name="robots" content="noindex, follow" />
+    <link rel="icon" type="image/png" href="/pwa-192x192.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&family=Playfair+Display:wght@400&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body {
+        background: #12100c;
+        color: #f5e8c8;
+        font-family: 'IBM Plex Sans', system-ui, sans-serif;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 48px 24px;
+        text-align: center;
+      }
+      .wrap { max-width: 560px; }
+      .code {
+        font-size: 13px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: #d99a2b;
+        margin-bottom: 22px;
+      }
+      h1 {
+        font-family: 'Playfair Display', Georgia, serif;
+        font-weight: 400;
+        font-size: clamp(30px, 6vw, 46px);
+        color: #f0a522;
+        line-height: 1.15;
+        margin-bottom: 20px;
+      }
+      p { color: #9a8f7a; line-height: 1.7; font-size: 16px; font-weight: 300; margin-bottom: 34px; }
+      .links { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+      a {
+        color: #f5e8c8;
+        text-decoration: none;
+        border: 1px solid rgba(240, 165, 34, 0.28);
+        border-radius: 4px;
+        padding: 11px 20px;
+        font-size: 14px;
+        transition: border-color 0.2s, color 0.2s;
+      }
+      a:hover { border-color: #f0a522; color: #f0a522; }
+      .hint { margin-top: 40px; font-size: 12.5px; color: #6b6252; letter-spacing: 0.04em; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="code">Error 404</div>
+      <h1>Nothing distils here</h1>
+      <p>
+        That address doesn't correspond to anything on the site. It may have
+        been mistyped, or it may have moved.
+      </p>
+      <div class="links">
+        <a href="/">The distillery</a>
+        <a href="/concepts/epoch-4">Epoch #4</a>
+        <a href="/sim">SedSim</a>
+      </div>
+      <p class="hint">Distilling complexity into clarity — from the quantum to the clinical.</p>
+    </div>
+  </body>
+</html>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,25 @@
-# Netlify _redirects — SPA routing + The Door subpath
+# Netlify _redirects
+#
+# Netlify matches real files in dist/ BEFORE consulting this file, so every
+# prerendered route — /, /sim, and the twelve /concepts/<slug> pages — is
+# served from its own HTML and never reaches these rules.
+#
+# What follows applies only to paths with no file behind them.
+
+# The Door — word-gated preview of The Relief Issue 01.
 /undercut    /undercut/index.html    200
-/*           /index.html             200
+
+# The instructor dashboard is the one client-only route: deliberately not
+# prerendered (a tool, not content), so it has no file of its own and needs
+# the SPA shell handed to it explicitly. Without this line the rule below
+# would 404 a working page.
+/instructor  /index.html             200
+
+# Everything else genuinely does not exist, and should say so.
+#
+# This previously read `/*  /index.html  200`, which meant every mistyped
+# link, stale URL and scanner probe returned the full home page with a 200 —
+# /wibble and /.env included. That is a soft 404: search engines index the
+# junk URL as a real page duplicating the home page, diluting the routes that
+# are real. Now they get a 404 status and a page that says so.
+/*           /404.html               404


### PR DESCRIPTION
Every nonexistent URL on the site returned **HTTP 200 with the full home page**:

```
/wibble                        → 200
/this-path-does-not-exist-9c3f → 200
/.env                          → 200   (57,130 bytes of index.html)
```

`public/_redirects` ended in `/*  /index.html  200`, so the SPA shell was handed to every unmatched path.

## Why this matters now

It was harmless when the site was one URL. It stopped being harmless the moment #166 gave it fourteen: every mistyped inbound link, stale URL, and scanner probe is now an indexable page duplicating the home page — diluting the routes that are real. Google classifies these as *Soft 404* and declines to index them, but only after spending crawl budget finding out.

## How I found it

While checking whether `/.env` or `/.git/config` were exposing anything across the three properties, after OVN Nexus's Cloudflare Signals page showed GPTBot probing those paths.

**Nothing is exposed.** The 200s here were the SPA fallback — byte-identical responses for `/.env` and `/.git/config` (57,130 bytes each), `content-type: text/html`, zero credential-shaped strings. The soft 404 underneath was the actual finding.

## The change

```diff
  /undercut    /undercut/index.html    200
+ /instructor  /index.html             200
- /*           /index.html             200
+ /*           /404.html               404
```

**Netlify matches real files in `dist/` before consulting `_redirects`**, so every prerendered route — `/`, `/sim`, and the twelve `/concepts/<slug>` pages — continues to serve its own HTML and never reaches the catch-all. Verified against the built output; all five checked routes still present as real files.

**`/instructor` needs its own rule.** It's the one client-only route, deliberately excluded from the prerender as a tool rather than content. Without that line the new catch-all would 404 a working page — the sort of thing that's easy to ship and unpleasant to discover later.

## The 404 page

`public/404.html` is static by design: it has to render when the JS bundle is the thing that failed, and a crawler hitting a dead URL shouldn't need to boot React to be told the page is gone.

`noindex, follow` — no value in indexing it, but its links to `/`, `/concepts/epoch-4`, and `/sim` are worth following.

## One known inconsistency

React Router's `*` route still does `<Navigate to="/" replace />`, so a bad link followed *within* the app redirects home rather than showing this page. That path doesn't affect crawlers or SEO — the static 404 covers every direct hit and every crawl. Worth tidying with a React `NotFound` component eventually, but it isn't what this PR is for.

## Verification

```
dist/404.html                       2,954 bytes, noindex
dist/_redirects                     /undercut → 200, /instructor → 200, /* → 404
dist/index.html                     ✓
dist/sim/index.html                 ✓
dist/concepts/epoch-4/index.html    ✓
dist/concepts/consciousness/…       ✓
dist/undercut/index.html            ✓
```

Typecheck clean, lint clean (16 pre-existing warnings, 0 errors), 56 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J494YzrA1h84uD3nPyg7HX)_