### PR TITLE
Match canonicals and sitemap to the URLs Netlify serves

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -207,7 +207,9 @@ const sitemap =
   ROUTES.map(
     (r) =>
       `  <url>\n` +
-      `    <loc>${SITE}${r === '/' ? '/' : r}</loc>\n` +
+      // Trailing slash matches what Netlify actually serves — /sim 301s to
+      // /sim/ — so the sitemap, the canonical tags and the served URL all agree.
+      `    <loc>${SITE}${r.endsWith('/') ? r : `${r}/`}</loc>\n` +
       `    <lastmod>${today}</lastmod>\n` +
       `    <changefreq>${changefreq(r)}</changefreq>\n` +
       `    <priority>${priority(r)}</priority>\n` +

--- a/src/lib/useDocumentMeta.ts
+++ b/src/lib/useDocumentMeta.ts
@@ -16,6 +16,20 @@ import { useEffect } from 'react';
 
 const SITE = 'https://thequantumdistillery.com';
 
+/**
+ * Netlify serves directory-index files under a trailing slash and 301s the
+ * bare form to it: a request for /sim redirects to /sim/. So /sim/ is the URL
+ * that actually returns 200, and it is what the canonical must name.
+ *
+ * Declaring /sim canonical while /sim only redirects points the tag at a URL
+ * that is never the final destination — a self-contradicting signal. Rather
+ * than fight the platform default, match it, and normalise in one place so
+ * callers cannot forget.
+ */
+function canonicalPath(path: string) {
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
 function setMeta(selector: string, attr: 'name' | 'property', key: string, content: string) {
   let el = document.head.querySelector<HTMLMetaElement>(selector);
   if (!el) {
@@ -49,7 +63,7 @@ export type DocumentMeta = {
 
 export function useDocumentMeta({ title, description, path, jsonLd, noindex }: DocumentMeta) {
   useEffect(() => {
-    const url = `${SITE}${path}`;
+    const url = `${SITE}${canonicalPath(path)}`;
 
     document.title = title;
     setMeta('meta[name="description"]', 'name', 'description', description);


### PR DESCRIPTION
Closes an inconsistency that arrived with the per-concept routes in #166.

## The mismatch

Netlify serves directory-index files under a trailing slash and 301s the bare form to it:

```
GET /sim                → 301 → /sim/
GET /concepts/epoch-4   → 301 → /concepts/epoch-4/
```

So `/sim/` is the URL that actually returns 200 — while the canonical tag and the sitemap both named `/sim`, a URL that is never the final destination.

Google generally resolves this in favour of the redirect target, so nothing was broken. But a page declaring itself canonical at an address that immediately redirects elsewhere is a self-contradicting signal, and it was mine.

## The fix

```diff
- const url = `${SITE}${path}`;
+ const url = `${SITE}${canonicalPath(path)}`;
```

Normalisation lives in one place inside `useDocumentMeta`, so callers can't forget it, and the prerender applies the same rule when writing the sitemap. Tags, sitemap, and served URL now all agree.

I chose to **match the platform rather than fight it** — disabling Netlify's pretty URLs would also have worked, but overriding a hosting default is the more fragile of the two, and it would leave the same trap for whoever adds the next route.

## How it surfaced

While verifying #167 on the deploy preview. Checking status codes *without* following redirects made the 301s visible — they'd been invisible in every earlier check because I'd used `curl -L` throughout, which silently follows them.

## Verification

```
canonical  /                              → https://thequantumdistillery.com/
canonical  /sim/                          → https://thequantumdistillery.com/sim/
canonical  /concepts/epoch-4/             → …/concepts/epoch-4/
canonical  /concepts/consciousness/       → …/concepts/consciousness/

sitemap entries without trailing slash: 0   (of 14)
```

Typecheck clean, lint clean, 56 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J494YzrA1h84uD3nPyg7HX)_